### PR TITLE
Use escaped potentially IPV6 host

### DIFF
--- a/reverse_engineering/connectionHelper.js
+++ b/reverse_engineering/connectionHelper.js
@@ -40,7 +40,7 @@ const close = () => {
 };
 
 const connectToInstance = async info => {
-	const host = info.host;
+	const host = info.escapedHostForUrl;
 	const port = info.port;
 	const clientOptions = {
 		traversalSource: graphName,


### PR DESCRIPTION
## Content

- Fixes wrong URL format when creating the Gremlin client