### PR TITLE
[HCK-10851] Fix/gremlin node 22 compatibility

### DIFF
--- a/forward_engineering/applyToInstanceHelper.js
+++ b/forward_engineering/applyToInstanceHelper.js
@@ -8,7 +8,7 @@ const applyToInstanceHelper = ({ sshService }) => ({
 		const clusterInfo = await neptuneInstance.getBucketInfo();
 		const info = {
 			...connectionInfo,
-			host: clusterInfo.ReaderEndpoint,
+			host: clusterInfo.Endpoint,
 			port: clusterInfo.Port,
 		};
 		return await connectionHelper.connect(info, sshService);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
     "name": "Neptune-Gremlin",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "Neptune-Gremlin",
-            "version": "0.2.5",
+            "version": "0.2.6",
             "hasInstallScript": true,
             "dependencies": {
                 "@aws-sdk/client-neptune": "3.687.0",
                 "@hackolade/fetch": "1.1.0",
                 "async": "3.2.6",
-                "gremlin": "3.7.2",
+                "gremlin": "3.7.3",
                 "lodash": "4.17.21"
             },
             "devDependencies": {
                 "@hackolade/hck-esbuild-plugins-pack": "0.0.1",
                 "@typescript-eslint/eslint-plugin": "7.11.0",
                 "@typescript-eslint/parser": "7.11.0",
-                "esbuild": "0.20.2",
+                "esbuild": "0.25.2",
                 "esbuild-plugin-clean": "1.0.1",
                 "esbuild-plugin-copy": "2.1.1",
                 "eslint": "8.57.0",
@@ -28,7 +28,7 @@
                 "eslint-plugin-import": "^2.26.0",
                 "eslint-plugin-prettier": "5.1.3",
                 "eslint-plugin-unused-imports": "3.2.0",
-                "lint-staged": "14.0.1",
+                "lint-staged": "15.5.1",
                 "prettier": "3.2.5",
                 "simple-git-hooks": "2.11.1"
             },
@@ -705,371 +705,428 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+            "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "aix"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+            "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+            "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+            "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+            "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+            "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+            "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+            "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+            "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+            "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+            "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+            "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
             "cpu": [
                 "mips64el"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+            "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+            "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+            "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+            "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
             "cpu": [
-                "x64"
+                "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+            "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+            "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+            "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+            "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+            "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+            "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2044,15 +2101,16 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "type-fest": "^1.0.2"
+                "environment": "^1.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2423,31 +2481,33 @@
             }
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-truncate": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "slice-ansi": "^5.0.0",
-                "string-width": "^5.0.0"
+                "string-width": "^7.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2475,15 +2535,17 @@
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {
@@ -2493,10 +2555,11 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2558,12 +2621,13 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -2660,17 +2724,25 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
-        },
         "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/es-abstract": {
             "version": "1.23.3",
@@ -2806,41 +2878,44 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+            "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.20.2",
-                "@esbuild/android-arm": "0.20.2",
-                "@esbuild/android-arm64": "0.20.2",
-                "@esbuild/android-x64": "0.20.2",
-                "@esbuild/darwin-arm64": "0.20.2",
-                "@esbuild/darwin-x64": "0.20.2",
-                "@esbuild/freebsd-arm64": "0.20.2",
-                "@esbuild/freebsd-x64": "0.20.2",
-                "@esbuild/linux-arm": "0.20.2",
-                "@esbuild/linux-arm64": "0.20.2",
-                "@esbuild/linux-ia32": "0.20.2",
-                "@esbuild/linux-loong64": "0.20.2",
-                "@esbuild/linux-mips64el": "0.20.2",
-                "@esbuild/linux-ppc64": "0.20.2",
-                "@esbuild/linux-riscv64": "0.20.2",
-                "@esbuild/linux-s390x": "0.20.2",
-                "@esbuild/linux-x64": "0.20.2",
-                "@esbuild/netbsd-x64": "0.20.2",
-                "@esbuild/openbsd-x64": "0.20.2",
-                "@esbuild/sunos-x64": "0.20.2",
-                "@esbuild/win32-arm64": "0.20.2",
-                "@esbuild/win32-ia32": "0.20.2",
-                "@esbuild/win32-x64": "0.20.2"
+                "@esbuild/aix-ppc64": "0.25.2",
+                "@esbuild/android-arm": "0.25.2",
+                "@esbuild/android-arm64": "0.25.2",
+                "@esbuild/android-x64": "0.25.2",
+                "@esbuild/darwin-arm64": "0.25.2",
+                "@esbuild/darwin-x64": "0.25.2",
+                "@esbuild/freebsd-arm64": "0.25.2",
+                "@esbuild/freebsd-x64": "0.25.2",
+                "@esbuild/linux-arm": "0.25.2",
+                "@esbuild/linux-arm64": "0.25.2",
+                "@esbuild/linux-ia32": "0.25.2",
+                "@esbuild/linux-loong64": "0.25.2",
+                "@esbuild/linux-mips64el": "0.25.2",
+                "@esbuild/linux-ppc64": "0.25.2",
+                "@esbuild/linux-riscv64": "0.25.2",
+                "@esbuild/linux-s390x": "0.25.2",
+                "@esbuild/linux-x64": "0.25.2",
+                "@esbuild/netbsd-arm64": "0.25.2",
+                "@esbuild/netbsd-x64": "0.25.2",
+                "@esbuild/openbsd-arm64": "0.25.2",
+                "@esbuild/openbsd-x64": "0.25.2",
+                "@esbuild/sunos-x64": "0.25.2",
+                "@esbuild/win32-arm64": "0.25.2",
+                "@esbuild/win32-ia32": "0.25.2",
+                "@esbuild/win32-x64": "0.25.2"
             }
         },
         "node_modules/esbuild-plugin-clean": {
@@ -3265,23 +3340,24 @@
             }
         },
         "node_modules/execa": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-            "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^4.3.0",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
                 "is-stream": "^3.0.0",
                 "merge-stream": "^2.0.0",
                 "npm-run-path": "^5.1.0",
                 "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.1.0",
                 "strip-final-newline": "^3.0.0"
             },
             "engines": {
-                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+                "node": ">=16.17"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -3508,6 +3584,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -3528,12 +3617,13 @@
             }
         },
         "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3677,9 +3767,9 @@
             "dev": true
         },
         "node_modules/gremlin": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/gremlin/-/gremlin-3.7.2.tgz",
-            "integrity": "sha512-8vPDhouXUm4A5vRuiDaTbj+1D0kaR2lTMJjTMi3HfXD0vlHX30FNYlyJVfU57+ugvUHBEUUuO+xYCqgxYle9ig==",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/gremlin/-/gremlin-3.7.3.tgz",
+            "integrity": "sha512-Mn12HDmSlT2gFzNbVD4vlIdsKJLqKNomu1LbJyXWVgBFl2STHp1F5XzvZVu44Y2K/OpHy/p/B2kHdEzDyQq3XA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "^6.0.3",
@@ -3774,12 +3864,13 @@
             }
         },
         "node_modules/human-signals": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
-                "node": ">=14.18.0"
+                "node": ">=16.17.0"
             }
         },
         "node_modules/ieee754": {
@@ -4000,6 +4091,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
             "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4109,6 +4201,7 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -4262,46 +4355,52 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
             }
         },
         "node_modules/lint-staged": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-14.0.1.tgz",
-            "integrity": "sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==",
+            "version": "15.5.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.1.tgz",
+            "integrity": "sha512-6m7u8mue4Xn6wK6gZvSCQwBvMBR36xfY24nF5bMTf2MHDYG6S3yhJuOgdYVw99hsjyDt2d4z168b3naI8+NWtQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chalk": "5.3.0",
-                "commander": "11.0.0",
-                "debug": "4.3.4",
-                "execa": "7.2.0",
-                "lilconfig": "2.1.0",
-                "listr2": "6.6.1",
-                "micromatch": "4.0.5",
-                "pidtree": "0.6.0",
-                "string-argv": "0.3.2",
-                "yaml": "2.3.1"
+                "chalk": "^5.4.1",
+                "commander": "^13.1.0",
+                "debug": "^4.4.0",
+                "execa": "^8.0.1",
+                "lilconfig": "^3.1.3",
+                "listr2": "^8.2.5",
+                "micromatch": "^4.0.8",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.2",
+                "yaml": "^2.7.0"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": ">=18.12.0"
             },
             "funding": {
                 "url": "https://opencollective.com/lint-staged"
             }
         },
         "node_modules/lint-staged/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -4310,28 +4409,21 @@
             }
         },
         "node_modules/listr2": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
-            "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.2.tgz",
+            "integrity": "sha512-vsBzcU4oE+v0lj4FhVLzr9dBTv4/fHIa57l+GCwovP8MoFNZJTOhGU8PXd4v2VJCbECAaijBiHntiekFMLvo0g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "cli-truncate": "^3.1.0",
+                "cli-truncate": "^4.0.0",
                 "colorette": "^2.0.20",
                 "eventemitter3": "^5.0.1",
-                "log-update": "^5.0.1",
-                "rfdc": "^1.3.0",
-                "wrap-ansi": "^8.1.0"
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "enquirer": ">= 2.3.0 < 3"
-            },
-            "peerDependenciesMeta": {
-                "enquirer": {
-                    "optional": true
-                }
+                "node": ">=18.0.0"
             }
         },
         "node_modules/locate-path": {
@@ -4361,29 +4453,31 @@
             "dev": true
         },
         "node_modules/log-update": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-            "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ansi-escapes": "^5.0.0",
-                "cli-cursor": "^4.0.0",
-                "slice-ansi": "^5.0.0",
-                "strip-ansi": "^7.0.1",
-                "wrap-ansi": "^8.0.1"
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/log-update/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4391,11 +4485,58 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
+        "node_modules/log-update/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+            "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+            "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
         "node_modules/log-update/node_modules/strip-ansi": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -4410,7 +4551,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -4422,12 +4564,13 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -4439,8 +4582,22 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4468,10 +4625,11 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4493,6 +4651,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
             "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^4.0.0"
             },
@@ -4508,6 +4667,7 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4614,6 +4774,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
             "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^4.0.0"
             },
@@ -4920,40 +5081,33 @@
             }
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/restore-cursor/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/restore-cursor/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "mimic-fn": "^2.1.0"
+                "mimic-function": "^5.0.0"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -4970,10 +5124,11 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-            "dev": true
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -5154,10 +5309,17 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/simple-git-hooks": {
             "version": "2.11.1",
@@ -5183,6 +5345,7 @@
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
             "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.0.0",
                 "is-fullwidth-code-point": "^4.0.0"
@@ -5199,6 +5362,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5225,27 +5389,29 @@
             }
         },
         "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5258,6 +5424,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -5343,6 +5510,7 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5464,18 +5632,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -5671,27 +5827,29 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5704,6 +5862,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
             "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -5716,6 +5875,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -5754,10 +5914,14 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
                 "node": ">= 14"
             }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@aws-sdk/client-neptune": "3.687.0",
         "@hackolade/fetch": "1.1.0",
         "async": "3.2.6",
-        "gremlin": "3.7.2",
+        "gremlin": "3.7.3",
         "lodash": "4.17.21"
     },
     "lint-staged": {
@@ -50,13 +50,14 @@
     "scripts": {
         "lint": "eslint . --max-warnings=0",
         "package": "node esbuild.package.js",
+        "install": "npx patch-package",
         "postinstall": "npx simple-git-hooks"
     },
     "devDependencies": {
         "@hackolade/hck-esbuild-plugins-pack": "0.0.1",
         "@typescript-eslint/eslint-plugin": "7.11.0",
         "@typescript-eslint/parser": "7.11.0",
-        "esbuild": "0.20.2",
+        "esbuild": "0.25.2",
         "esbuild-plugin-clean": "1.0.1",
         "esbuild-plugin-copy": "2.1.1",
         "eslint": "8.57.0",
@@ -65,7 +66,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "5.1.3",
         "eslint-plugin-unused-imports": "3.2.0",
-        "lint-staged": "14.0.1",
+        "lint-staged": "15.5.1",
         "prettier": "3.2.5",
         "simple-git-hooks": "2.11.1"
     }

--- a/patches/gremlin+3.7.3.patch
+++ b/patches/gremlin+3.7.3.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/gremlin/lib/driver/connection.js b/node_modules/gremlin/lib/driver/connection.js
+index 38f6ee7..98e3749 100644
+--- a/node_modules/gremlin/lib/driver/connection.js
++++ b/node_modules/gremlin/lib/driver/connection.js
+@@ -124,7 +124,23 @@ class Connection extends EventEmitter {
+       }
+     }
+ 
+-    const WebSocket = globalThis.WebSocket ?? (await import('ws')).default;
++
++    /**
++     * Starting Node 22, there is a basic Websocket implementation provided on global context
++     * breaking the initial implementation which uses the ws lib in Node like environments.
++     * The Node 22 Websocket implementation is not complete and Gremlin servers are cutting
++     * the connections when they are done in a secured context (wss), e.g. websockets with tls.
++     * When using Node 22's implementation the server is cutting the connection with non-101 response code.
++     */
++    const isNode = () => typeof process !== 'undefined' && !!process.versions && !!process.versions.node;
++    const getWebsocketImplementation =  async () => {
++      if(isNode()){
++        return (await import('ws')).default;
++      }
++      // In browser return the standard implementation
++      return globalThis.WebSocket;
++    }
++    const WebSocket =  await getWebsocketImplementation();
+ 
+     this._ws = new WebSocket(
+       this.url,

--- a/reverse_engineering/connectionHelper.js
+++ b/reverse_engineering/connectionHelper.js
@@ -62,7 +62,8 @@ const connectToInstance = async info => {
 };
 
 const createPlainGraphSonReader = () => ({
-	read(obj) {
+	readResponse(buffer) {
+		const obj = JSON.parse(buffer.toString());
 		return {
 			...obj,
 			result: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10851" title="HCK-10851" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10851</a>  Fix Neptune-Gremlin connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content
The plugin wasn't working anymore since the upgrade to Node 22 runtime with recent Electron majors.

This PR fixes a few things 
- Patches the gremlin lib to force the same behavior as in Node 20
- Make sure the patch is automatically applied when running `npm ci | install`
- We use now the writer endpoint instead of the read-only one when doing apply-to-instance.
- Change our custom reader to follow the gremlin api (read -> readResponse)
- Change the custom reader to comply with the fact that response is binary/buffer encoded

While there are still a few issues that need to be follow up in next iterations
- We should batch queries when writing (e.g. apply script) -> looks like we open a connection for each query we run with the current approach
- The applyToInstance is still failing on writing edges (see https://hackolade.atlassian.net/browse/HCK - 10858)
